### PR TITLE
cgahlon/add projecthook missing fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+module github.com/cgahlon/go-gitlab
+
 go 1.19
 
 require (
@@ -5,6 +7,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/stretchr/testify v1.8.1
+	github.com/cgahlon/go-gitlab v1.114.0
 	golang.org/x/oauth2 v0.6.0
 	golang.org/x/time v0.3.0
 )
@@ -19,4 +22,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-module github.com/cgahlon/go-gitlab

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/xanzy/go-gitlab
-
 go 1.19
 
 require (
@@ -20,3 +18,5 @@ require (
 	google.golang.org/protobuf v1.29.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+module github.com/cgahlon/go-gitlab

--- a/projects.go
+++ b/projects.go
@@ -1270,6 +1270,8 @@ type HookCustomHeader struct {
 type ProjectHook struct {
 	ID                        int                 `json:"id"`
 	URL                       string              `json:"url"`
+	Name                      *string             `json:"name,omitempty"`
+	Description               *string             `json:"description,omitempty"`
 	ConfidentialNoteEvents    bool                `json:"confidential_note_events"`
 	ProjectID                 int                 `json:"project_id"`
 	PushEvents                bool                `json:"push_events"`
@@ -1352,6 +1354,8 @@ func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...R
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#add-project-hook
 type AddProjectHookOptions struct {
+	Name                      *string              `url:"name,omitempty" json:"name,omitempty"`
+	Description               *string              `url:"description,omitempty" json:"description,omitempty"`
 	ConfidentialIssuesEvents  *bool                `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	ConfidentialNoteEvents    *bool                `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	DeploymentEvents          *bool                `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`
@@ -1403,6 +1407,8 @@ func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOpt
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#edit-project-hook
 type EditProjectHookOptions struct {
+	Name                      *string              `url:"name,omitempty" json:"name,omitempty"`
+	Description               *string              `url:"description,omitempty" json:"description,omitempty"`
 	ConfidentialIssuesEvents  *bool                `url:"confidential_issues_events,omitempty" json:"confidential_issues_events,omitempty"`
 	ConfidentialNoteEvents    *bool                `url:"confidential_note_events,omitempty" json:"confidential_note_events,omitempty"`
 	DeploymentEvents          *bool                `url:"deployment_events,omitempty" json:"deployment_events,omitempty"`


### PR DESCRIPTION
Add 'name' and 'description' to project hook structs so they support all the fields supported by the API